### PR TITLE
Deprecated scipy imresize -> numpy resize and PIL.Image

### DIFF
--- a/util/util.py
+++ b/util/util.py
@@ -48,11 +48,6 @@ def diagnose_network(net, name='network'):
     print(mean)
 
 
-def save_image(image_numpy, image_path):
-    image_pil = Image.fromarray(image_numpy)
-    image_pil.save(image_path)
-
-
 def print_numpy(x, val=True, shp=False):
     x = x.astype(np.float64)
     if shp:

--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -23,9 +23,9 @@ def save_images(webpage, visuals, image_path, scale_range, aspect_ratio=1.0, wid
         save_path = os.path.join(image_dir, image_name)
         h, w, _ = im.shape
         if aspect_ratio > 1.0:
-            im = np.array(Image.fromarray(im).resize( h, int(w * aspect_ratio) ))
+            im = np.array(Image.fromarray(im).resize( (h, int(w * aspect_ratio)) ))
         if aspect_ratio < 1.0:
-            im = np.array(Image.fromarray(im).resize( int(h / aspect_ratio), w ))
+            im = np.array(Image.fromarray(im).resize( (int(h / aspect_ratio), w) ))
         util.save_image(im, save_path)
 
         ims.append(image_name)

--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -4,7 +4,7 @@ import ntpath
 import time
 from . import util
 from . import html
-from scipy.misc import imresize
+from PIL import Image
 
 
 # save image to the disk
@@ -23,9 +23,9 @@ def save_images(webpage, visuals, image_path, scale_range, aspect_ratio=1.0, wid
         save_path = os.path.join(image_dir, image_name)
         h, w, _ = im.shape
         if aspect_ratio > 1.0:
-            im = imresize(im, (h, int(w * aspect_ratio)), interp='bicubic')
+            im = np.array(Image.fromarray(im).resize( h, int(w * aspect_ratio) ))
         if aspect_ratio < 1.0:
-            im = imresize(im, (int(h / aspect_ratio), w), interp='bicubic')
+            im = np.array(Image.fromarray(im).resize( int(h / aspect_ratio), w ))
         util.save_image(im, save_path)
 
         ims.append(image_name)

--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -23,10 +23,10 @@ def save_images(webpage, visuals, image_path, scale_range, aspect_ratio=1.0, wid
         save_path = os.path.join(image_dir, image_name)
         h, w, _ = im.shape
         if aspect_ratio > 1.0:
-            im = np.array(Image.fromarray(im).resize( (h, int(w * aspect_ratio)) ))
+            im = Image.fromarray(im).resize( (h, int(w * aspect_ratio)) )
         if aspect_ratio < 1.0:
-            im = np.array(Image.fromarray(im).resize( (int(h / aspect_ratio), w) ))
-        util.save_image(im, save_path)
+            im = Image.fromarray(im).resize( (int(h / aspect_ratio), w) )
+        im.save(save_path)
 
         ims.append(image_name)
         txts.append(label)
@@ -123,7 +123,8 @@ class Visualizer():
             for label, image in visuals.items():
                 image_numpy = util.tensor2im(image, self.scale_range)
                 img_path = os.path.join(self.img_dir, 'epoch%.3d_%s.png' % (epoch, label))
-                util.save_image(image_numpy, img_path)
+                im = Image.fromarray(image_numpy)
+                im.save(img_path)
             # update website
             webpage = html.HTML(self.web_dir, 'Experiment name = %s' % self.name, reflesh=1)
             for n in range(epoch, 0, -1):


### PR DESCRIPTION
scipy.misc.imresize removed as of v1.3.0, replaced it with PIL.Image.from_array and numpy.resize.
- https://docs.scipy.org/doc/scipy-1.2.0/reference/generated/scipy.misc.imresize.html
- https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/652